### PR TITLE
TST: read files as utf-8-sig (#143)

### DIFF
--- a/manubot/cite/tests/test_citeproc.py
+++ b/manubot/cite/tests/test_citeproc.py
@@ -15,6 +15,19 @@ csl_instances = [
 ]
 
 
+def load_json(path):
+    return json.loads(path.read_text(encoding='utf-8-sig'))
+
+    
+def test_json_is_readable_on_windows_in_different_oem_encoding():
+    name = 'crossref-deep-review-csl'
+    path = directory / 'csl-json' / name / 'raw.json'
+    content = path.read_text(encoding='utf-8-sig')
+    assert content
+    json1 = load_json(path)
+    assert json1
+    
+
 @pytest.mark.parametrize('name', csl_instances)
 def test_remove_jsonschema_errors(name):
     """
@@ -30,8 +43,8 @@ def test_remove_jsonschema_errors(name):
     pruned.json as that also relies on remove_jsonschema_errors for pruning.
     """
     data_dir = directory / 'csl-json' / name
-    raw = json.loads(data_dir.joinpath('raw.json').read_text())
-    expected = json.loads(data_dir.joinpath('pruned.json').read_text())
+    raw = load_json(data_dir / 'raw.json')
+    expected = load_json(data_dir / 'pruned.json')
     pruned = remove_jsonschema_errors(raw)
     assert pruned == expected
 

--- a/manubot/pandoc/tests/test_bibliography.py
+++ b/manubot/pandoc/tests/test_bibliography.py
@@ -43,7 +43,7 @@ def test_load_bibliography_from_text(path):
     """
     https://zbib.org/c7f95cdef6d6409c92ffde24d519435d
     """
-    text = path.read_text()
+    text = path.read_text(encoding='utf-8-sig')
     input_format = path.suffix[1:]
     csl_json = load_bibliography(text=text, input_format=input_format)
     assert len(csl_json) == 2


### PR DESCRIPTION
merges https://github.com/manubot/manubot/pull/143

Force test_remove_jsonschema_errors and test_load_bibliography_from_text
to use the utf-8-sig encoding to read files. Prevents tests from failing on certain
Windows systems that default to opening files with a different encoding.