### PR TITLE
split cite.util into csl_item & citekey submods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Thumbs.db
 
 ## Text Editors
 .vscode
+.idea/

--- a/manubot/cite/__init__.py
+++ b/manubot/cite/__init__.py
@@ -5,7 +5,7 @@ __all__ = [
     'standardize_citekey',
 ]
 
-from manubot.cite.util import (
+from manubot.cite.citekey import (
     citekey_to_csl_item,
     standardize_citekey,
 )

--- a/manubot/cite/cite_command.py
+++ b/manubot/cite/cite_command.py
@@ -4,11 +4,11 @@ import pathlib
 import subprocess
 import sys
 
-from manubot.cite import (
+from manubot.cite.citekey import (
     citekey_to_csl_item,
     standardize_citekey,
+    is_valid_citekey
 )
-from manubot.cite.util import is_valid_citekey
 from manubot.pandoc.util import get_pandoc_info
 from manubot.util import shlex_join
 

--- a/manubot/cite/citekey.py
+++ b/manubot/cite/citekey.py
@@ -1,3 +1,16 @@
+"""Functions importable from manubot.cite submodule (submodule API):
+
+  standardize_citekey()
+  citekey_to_csl_item()
+
+Helpers:
+
+  inspect_citekey()
+  is_valid_citekey() - also used in manubot.process
+  shorten_citekey() - used solely in manubot.process
+  infer_citekey_prefix()
+
+"""
 import functools
 import logging
 import re
@@ -301,58 +314,3 @@ def infer_citekey_prefix(citekey):
         if citekey.lower().startswith(prefix):
             return prefix + citekey[len(prefix):]
     return f'raw:{citekey}'
-
-
-def csl_item_set_standard_id(csl_item):
-    """
-    Extract the standard_id (standard citation key) for a csl_item and modify the csl_item in-place to set its "id" field.
-    The standard_id is extracted from a "standard_citation" field, the "note" field, or the "id" field.
-    If extracting the citation from the "id" field, uses the infer_citekey_prefix function to set the prefix.
-    For example, if the extracted standard_id does not begin with a supported prefix (e.g. "doi:", "pmid:"
-    or "raw:"), the citation is assumed to be raw and given a "raw:" prefix. The extracted citation
-    (referred to as "original_standard_id") is checked for validity and standardized, after which it is
-    the final "standard_id".
-
-    Regarding csl_item modification, the csl_item "id" field is set to the standard_citation and the note field
-    is created or updated with key-value pairs for standard_id, original_standard_id, and original_id.
-
-    Note that the Manubot software generally refers to the "id" of a CSL Item as a citekey.
-    However, in this context, we use "id" rather than "citekey" for consistency with CSL's "id" field.
-    """
-    if not isinstance(csl_item, dict):
-        raise ValueError("csl_item must be a CSL Data Item represented as a Python dictionary")
-
-    from manubot.cite.citeproc import (
-        append_to_csl_item_note,
-        parse_csl_item_note,
-    )
-    note_dict = parse_csl_item_note(csl_item.get('note', ''))
-
-    original_id = None
-    original_standard_id = None
-    if 'id' in csl_item:
-        original_id = csl_item['id']
-        original_standard_id = infer_citekey_prefix(original_id)
-    if 'standard_id' in note_dict:
-        original_standard_id = note_dict['standard_id']
-    if 'standard_citation' in csl_item:
-        original_standard_id = csl_item.pop('standard_citation')
-    if original_standard_id is None:
-        raise ValueError(
-            'csl_item_set_standard_id could not detect a field with a citation / standard_citation. '
-            'Consider setting the CSL Item "id" field.'
-        )
-    assert is_valid_citekey(original_standard_id, allow_raw=True)
-    standard_id = standardize_citekey(original_standard_id, warn_if_changed=False)
-    add_to_note = {}
-    if original_id and original_id != standard_id:
-        if original_id != note_dict.get('original_id'):
-            add_to_note['original_id'] = original_id
-    if original_standard_id and original_standard_id != standard_id:
-        if original_standard_id != note_dict.get('original_standard_id'):
-            add_to_note['original_standard_id'] = original_standard_id
-    if standard_id != note_dict.get('standard_id'):
-        add_to_note['standard_id'] = standard_id
-    append_to_csl_item_note(csl_item, dictionary=add_to_note)
-    csl_item['id'] = standard_id
-    return csl_item

--- a/manubot/cite/csl_item.py
+++ b/manubot/cite/csl_item.py
@@ -1,0 +1,57 @@
+from manubot.cite.citekey import standardize_citekey, infer_citekey_prefix, is_valid_citekey
+
+
+def csl_item_set_standard_id(csl_item):
+    """
+    Extract the standard_id (standard citation key) for a csl_item and modify the csl_item in-place to set its "id" field.
+    The standard_id is extracted from a "standard_citation" field, the "note" field, or the "id" field.
+    If extracting the citation from the "id" field, uses the infer_citekey_prefix function to set the prefix.
+    For example, if the extracted standard_id does not begin with a supported prefix (e.g. "doi:", "pmid:"
+    or "raw:"), the citation is assumed to be raw and given a "raw:" prefix. The extracted citation
+    (referred to as "original_standard_id") is checked for validity and standardized, after which it is
+    the final "standard_id".
+
+    Regarding csl_item modification, the csl_item "id" field is set to the standard_citation and the note field
+    is created or updated with key-value pairs for standard_id, original_standard_id, and original_id.
+
+    Note that the Manubot software generally refers to the "id" of a CSL Item as a citekey.
+    However, in this context, we use "id" rather than "citekey" for consistency with CSL's "id" field.
+    """
+    if not isinstance(csl_item, dict):
+        raise ValueError(
+            "csl_item must be a CSL Data Item represented as a Python dictionary")
+
+    from manubot.cite.citeproc import (
+        append_to_csl_item_note,
+        parse_csl_item_note,
+    )
+    note_dict = parse_csl_item_note(csl_item.get('note', ''))
+
+    original_id = None
+    original_standard_id = None
+    if 'id' in csl_item:
+        original_id = csl_item['id']
+        original_standard_id = infer_citekey_prefix(original_id)
+    if 'standard_id' in note_dict:
+        original_standard_id = note_dict['standard_id']
+    if 'standard_citation' in csl_item:
+        original_standard_id = csl_item.pop('standard_citation')
+    if original_standard_id is None:
+        raise ValueError(
+            'csl_item_set_standard_id could not detect a field with a citation / standard_citation. '
+            'Consider setting the CSL Item "id" field.')
+    assert is_valid_citekey(original_standard_id, allow_raw=True)
+    standard_id = standardize_citekey(
+        original_standard_id, warn_if_changed=False)
+    add_to_note = {}
+    if original_id and original_id != standard_id:
+        if original_id != note_dict.get('original_id'):
+            add_to_note['original_id'] = original_id
+    if original_standard_id and original_standard_id != standard_id:
+        if original_standard_id != note_dict.get('original_standard_id'):
+            add_to_note['original_standard_id'] = original_standard_id
+    if standard_id != note_dict.get('standard_id'):
+        add_to_note['standard_id'] = standard_id
+    append_to_csl_item_note(csl_item, dictionary=add_to_note)
+    csl_item['id'] = standard_id
+    return csl_item

--- a/manubot/cite/tests/test_citekey.py
+++ b/manubot/cite/tests/test_citekey.py
@@ -1,0 +1,100 @@
+"""Tests rest of functions in manubot.cite, not covered by test_citekey_api.py."""
+
+import pytest
+
+from manubot.cite.citekey import (
+    citekey_pattern,
+    shorten_citekey,
+    infer_citekey_prefix,
+    inspect_citekey,
+)
+
+
+@pytest.mark.parametrize("citation_string", [
+    ('@doi:10.5061/dryad.q447c/1'),
+    ('@arxiv:1407.3561v1'),
+    ('@doi:10.1007/978-94-015-6859-3_4'),
+    ('@tag:tag_with_underscores'),
+    ('@tag:tag-with-hyphens'),
+    ('@url:https://greenelab.github.io/manubot-rootstock/'),
+    ('@tag:abc123'),
+    ('@tag:123abc'),
+])
+def test_citekey_pattern_match(citation_string):
+    match = citekey_pattern.fullmatch(citation_string)
+    assert match
+
+
+@pytest.mark.parametrize("citation_string", [
+    ('doi:10.5061/dryad.q447c/1'),
+    ('@tag:abc123-'),
+    ('@tag:abc123_'),
+    ('@-tag:abc123'),
+    ('@_tag:abc123'),
+])
+def test_citekey_pattern_no_match(citation_string):
+    match = citekey_pattern.fullmatch(citation_string)
+    assert match is None
+
+
+@pytest.mark.parametrize("standard_citekey,expected", [
+    ('doi:10.5061/dryad.q447c/1', 'kQFQ8EaO'),
+    ('arxiv:1407.3561v1', '16kozZ9Ys'),
+    ('pmid:24159271', '11sli93ov'),
+    ('url:http://blog.dhimmel.com/irreproducible-timestamps/', 'QBWMEuxW'),
+])
+def test_shorten_citekey(standard_citekey, expected):
+    short_citekey = shorten_citekey(standard_citekey)
+    assert short_citekey == expected
+
+
+@pytest.mark.parametrize('citekey', [
+    'doi:10.7717/peerj.705',
+    'doi:10/b6vnmd',
+    'pmcid:PMC4304851',
+    'pmid:25648772',
+    'arxiv:1407.3561',
+    'isbn:978-1-339-91988-1',
+    'isbn:1-339-91988-5',
+    'wikidata:Q1',
+    'wikidata:Q50051684',
+    'url:https://peerj.com/articles/705/',
+])
+def test_inspect_citekey_passes(citekey):
+    """
+    These citekeys should pass inspection by inspect_citekey.
+    """
+    assert inspect_citekey(citekey) is None
+
+
+@pytest.mark.parametrize(['citekey', 'contains'], [
+    ('doi:10.771/peerj.705', 'Double check the DOI'),
+    ('doi:10/b6v_nmd', 'Double check the shortDOI'),
+    ('doi:7717/peerj.705', "must start with '10.'"),
+    ('doi:b6vnmd', "must start with '10.'"),
+    ('pmcid:25648772', "must start with 'PMC'"),
+    ('pmid:PMC4304851', "Should 'pmid:PMC4304851' switch the citation source to 'pmcid'?"),
+    ('isbn:1-339-91988-X', 'identifier violates the ISBN syntax'),
+    ('wikidata:P212', "item IDs must start with 'Q'"),
+    ('wikidata:QABCD', 'does not conform to the Wikidata regex'),
+])
+def test_inspect_citekey_fails(citekey, contains):
+    """
+    These citekeys should fail inspection by inspect_citekey.
+    """
+    report = inspect_citekey(citekey)
+    assert report is not None
+    assert isinstance(report, str)
+    assert contains in report
+
+
+@pytest.mark.parametrize(['citation', 'expect'], [
+    ('doi:not-a-real-doi', 'doi:not-a-real-doi'),
+    ('DOI:not-a-real-doi', 'doi:not-a-real-doi'),
+    ('uRl:mixed-case-prefix', 'url:mixed-case-prefix'),
+    ('raw:raw-citation', 'raw:raw-citation'),
+    ('no-prefix', 'raw:no-prefix'),
+    ('no-prefix:but-colon', 'raw:no-prefix:but-colon'),
+])
+def test_infer_citekey_prefix(citation, expect):
+    assert infer_citekey_prefix(citation) == expect

--- a/manubot/cite/tests/test_citekey_api.py
+++ b/manubot/cite/tests/test_citekey_api.py
@@ -1,54 +1,11 @@
-import copy
+"""Tests API-level functions in manubot.cite. Both functions are found in citekey.py"""
 
 import pytest
 
-from manubot.cite.util import (
-    citekey_pattern,
+from manubot.cite import (
     citekey_to_csl_item,
-    csl_item_set_standard_id,
-    shorten_citekey,
-    infer_citekey_prefix,
-    inspect_citekey,
     standardize_citekey,
 )
-
-
-@pytest.mark.parametrize("citation_string", [
-    ('@doi:10.5061/dryad.q447c/1'),
-    ('@arxiv:1407.3561v1'),
-    ('@doi:10.1007/978-94-015-6859-3_4'),
-    ('@tag:tag_with_underscores'),
-    ('@tag:tag-with-hyphens'),
-    ('@url:https://greenelab.github.io/manubot-rootstock/'),
-    ('@tag:abc123'),
-    ('@tag:123abc'),
-])
-def test_citekey_pattern_match(citation_string):
-    match = citekey_pattern.fullmatch(citation_string)
-    assert match
-
-
-@pytest.mark.parametrize("citation_string", [
-    ('doi:10.5061/dryad.q447c/1'),
-    ('@tag:abc123-'),
-    ('@tag:abc123_'),
-    ('@-tag:abc123'),
-    ('@_tag:abc123'),
-])
-def test_citekey_pattern_no_match(citation_string):
-    match = citekey_pattern.fullmatch(citation_string)
-    assert match is None
-
-
-@pytest.mark.parametrize("standard_citekey,expected", [
-    ('doi:10.5061/dryad.q447c/1', 'kQFQ8EaO'),
-    ('arxiv:1407.3561v1', '16kozZ9Ys'),
-    ('pmid:24159271', '11sli93ov'),
-    ('url:http://blog.dhimmel.com/irreproducible-timestamps/', 'QBWMEuxW'),
-])
-def test_shorten_citekey(standard_citekey, expected):
-    short_citekey = shorten_citekey(standard_citekey)
-    assert short_citekey == expected
 
 
 @pytest.mark.parametrize("citekey,expected", [
@@ -71,46 +28,6 @@ def test_standardize_citekey(citekey, expected):
     """
     output = standardize_citekey(citekey)
     assert output == expected
-
-
-@pytest.mark.parametrize('citekey', [
-    'doi:10.7717/peerj.705',
-    'doi:10/b6vnmd',
-    'pmcid:PMC4304851',
-    'pmid:25648772',
-    'arxiv:1407.3561',
-    'isbn:978-1-339-91988-1',
-    'isbn:1-339-91988-5',
-    'wikidata:Q1',
-    'wikidata:Q50051684',
-    'url:https://peerj.com/articles/705/',
-])
-def test_inspect_citekey_passes(citekey):
-    """
-    These citekeys should pass inspection by inspect_citekey.
-    """
-    assert inspect_citekey(citekey) is None
-
-
-@pytest.mark.parametrize(['citekey', 'contains'], [
-    ('doi:10.771/peerj.705', 'Double check the DOI'),
-    ('doi:10/b6v_nmd', 'Double check the shortDOI'),
-    ('doi:7717/peerj.705', "must start with '10.'"),
-    ('doi:b6vnmd', "must start with '10.'"),
-    ('pmcid:25648772', "must start with 'PMC'"),
-    ('pmid:PMC4304851', "Should 'pmid:PMC4304851' switch the citation source to 'pmcid'?"),
-    ('isbn:1-339-91988-X', 'identifier violates the ISBN syntax'),
-    ('wikidata:P212', "item IDs must start with 'Q'"),
-    ('wikidata:QABCD', 'does not conform to the Wikidata regex'),
-])
-def test_inspect_citekey_fails(citekey, contains):
-    """
-    These citekeys should fail inspection by inspect_citekey.
-    """
-    report = inspect_citekey(citekey)
-    assert report is not None
-    assert isinstance(report, str)
-    assert contains in report
 
 
 @pytest.mark.xfail(reason='https://twitter.com/dhimmel/status/950443969313419264')
@@ -230,78 +147,3 @@ def test_citekey_to_csl_item_isbn():
     csl_item = citekey_to_csl_item('isbn:9780387950693')
     assert csl_item['type'] == 'book'
     assert csl_item['title'] == 'Complex analysis'
-
-
-@pytest.mark.parametrize(['citation', 'expect'], [
-    ('doi:not-a-real-doi', 'doi:not-a-real-doi'),
-    ('DOI:not-a-real-doi', 'doi:not-a-real-doi'),
-    ('uRl:mixed-case-prefix', 'url:mixed-case-prefix'),
-    ('raw:raw-citation', 'raw:raw-citation'),
-    ('no-prefix', 'raw:no-prefix'),
-    ('no-prefix:but-colon', 'raw:no-prefix:but-colon'),
-])
-def test_infer_citekey_prefix(citation, expect):
-    assert infer_citekey_prefix(citation) == expect
-
-
-@pytest.mark.parametrize(
-    ['csl_item', 'standard_citation'],
-    [
-        (
-            {'id': 'my-id', 'standard_citation': 'doi:10.7554/elife.32822'},
-            'doi:10.7554/elife.32822',
-        ),
-        (
-            {'id': 'doi:10.7554/elife.32822'},
-            'doi:10.7554/elife.32822',
-        ),
-        (
-            {'id': 'doi:10.7554/ELIFE.32822'},
-            'doi:10.7554/elife.32822',
-        ),
-        (
-            {'id': 'my-id'},
-            'raw:my-id',
-        ),
-    ],
-    ids=[
-        'from_standard_citation',
-        'from_doi_id',
-        'from_doi_id_standardize',
-        'from_raw_id',
-    ]
-)
-def test_csl_item_set_standard_id(csl_item, standard_citation):
-    output = csl_item_set_standard_id(csl_item)
-    assert output is csl_item
-    assert output['id'] == standard_citation
-
-
-def test_csl_item_set_standard_id_repeated():
-    csl_item = {
-        'id': 'pmid:1',
-        'type': 'article-journal',
-    }
-    # csl_item_0 = copy.deepcopy(csl_item)
-    csl_item_1 = copy.deepcopy(csl_item_set_standard_id(csl_item))
-    assert 'standard_citation' not in 'csl_item'
-    csl_item_2 = copy.deepcopy(csl_item_set_standard_id(csl_item))
-    assert csl_item_1 == csl_item_2
-
-
-def test_csl_item_set_standard_id_note():
-    """
-    Test extracting standard_id from a note and setting additional
-    note fields.
-    """
-    csl_item = {
-        'id': 'original-id',
-        'type': 'article-journal',
-        'note': 'standard_id: doi:10.1371/journal.PPAT.1006256',
-    }
-    csl_item_set_standard_id(csl_item)
-    assert csl_item['id'] == 'doi:10.1371/journal.ppat.1006256'
-    from manubot.cite.citeproc import parse_csl_item_note
-    note_dict = parse_csl_item_note(csl_item['note'])
-    assert note_dict['original_id'] == 'original-id'
-    assert note_dict['original_standard_id'] == 'doi:10.1371/journal.PPAT.1006256'

--- a/manubot/cite/tests/test_csl_item.py
+++ b/manubot/cite/tests/test_csl_item.py
@@ -1,0 +1,69 @@
+import copy
+import pytest
+
+from manubot.cite.csl_item import (
+    csl_item_set_standard_id)
+
+
+@pytest.mark.parametrize(
+    ['csl_item', 'standard_citation'],
+    [
+        (
+            {'id': 'my-id', 'standard_citation': 'doi:10.7554/elife.32822'},
+            'doi:10.7554/elife.32822',
+        ),
+        (
+            {'id': 'doi:10.7554/elife.32822'},
+            'doi:10.7554/elife.32822',
+        ),
+        (
+            {'id': 'doi:10.7554/ELIFE.32822'},
+            'doi:10.7554/elife.32822',
+        ),
+        (
+            {'id': 'my-id'},
+            'raw:my-id',
+        ),
+    ],
+    ids=[
+        'from_standard_citation',
+        'from_doi_id',
+        'from_doi_id_standardize',
+        'from_raw_id',
+    ]
+)
+def test_csl_item_set_standard_id(csl_item, standard_citation):
+    output = csl_item_set_standard_id(csl_item)
+    assert output is csl_item
+    assert output['id'] == standard_citation
+
+
+def test_csl_item_set_standard_id_repeated():
+    csl_item = {
+        'id': 'pmid:1',
+        'type': 'article-journal',
+    }
+    # csl_item_0 = copy.deepcopy(csl_item)
+    csl_item_1 = copy.deepcopy(csl_item_set_standard_id(csl_item))
+    assert 'standard_citation' not in 'csl_item'
+    csl_item_2 = copy.deepcopy(csl_item_set_standard_id(csl_item))
+    assert csl_item_1 == csl_item_2
+
+
+def test_csl_item_set_standard_id_note():
+    """
+    Test extracting standard_id from a note and setting additional
+    note fields.
+    """
+    csl_item = {
+        'id': 'original-id',
+        'type': 'article-journal',
+        'note': 'standard_id: doi:10.1371/journal.PPAT.1006256',
+    }
+    csl_item_set_standard_id(csl_item)
+    assert csl_item['id'] == 'doi:10.1371/journal.ppat.1006256'
+    from manubot.cite.citeproc import parse_csl_item_note
+    note_dict = parse_csl_item_note(csl_item['note'])
+    assert note_dict['original_id'] == 'original-id'
+    assert note_dict['original_standard_id'] == 'doi:10.1371/journal.PPAT.1006256'
+

--- a/manubot/cite/tests/test_url.py
+++ b/manubot/cite/tests/test_url.py
@@ -35,7 +35,8 @@ def test_get_url_csl_item_zotero_manubot():
     assert csl_item['author'][1]['family'] == 'Slochower'
     # Zotero CSL exporter returns mixed string/int date-parts
     # https://github.com/zotero/zotero/issues/1603
-    assert [int(x) for x in csl_item['issued']['date-parts'][0]] == [2018, 12, 18]
+    assert [int(x) for x in csl_item['issued']
+            ['date-parts'][0]] == [2018, 12, 18]
 
 
 def test_get_url_csl_item_zotero_github():
@@ -48,8 +49,19 @@ def test_get_url_csl_item_zotero_github():
       --data 'https://github.com/pandas-dev/pandas/tree/d5e5bf761092c59eeb9b8750f05f2bc29fb45927' \
       'https://translate.manubot.org/web'
     ```
+
+    Note: this test may have temporary failures, due to performance of
+          translation-server. It seems that sometimes translation-server
+          returns a different title for the same URL. A real mystery.
+
+    See also:
+        https://github.com/manubot/manubot/pull/139#discussion_r328703233
+
+    Proposed action:
+        Probably should inquire upstream or change the test.
     """
     url = 'https://github.com/pandas-dev/pandas/tree/d5e5bf761092c59eeb9b8750f05f2bc29fb45927'
     csl_item = get_url_csl_item_zotero(url)
+    # FIXME: arbitraryly, csl_item['abstract'], and not csl_item['title'] contains the title.
     assert csl_item['title'].startswith('Flexible and powerful data analysis')
     assert csl_item['source'] == 'GitHub'

--- a/manubot/process/bibliography.py
+++ b/manubot/process/bibliography.py
@@ -7,10 +7,8 @@ from manubot.cite.citeproc import (
     append_to_csl_item_note,
     csl_item_passthrough,
 )
-from manubot.cite.util import (
-    csl_item_set_standard_id,
-    shorten_citekey,
-)
+from manubot.cite.csl_item import csl_item_set_standard_id
+from manubot.cite.citekey import shorten_citekey
 
 
 def load_bibliography(path):

--- a/manubot/process/manuscript.py
+++ b/manubot/process/manuscript.py
@@ -5,10 +5,7 @@ import logging
 import pathlib
 import re
 
-from manubot.cite.util import (
-    citekey_pattern,
-    is_valid_citekey,
-)
+from manubot.cite.citekey import citekey_pattern, is_valid_citekey
 
 
 def get_citekeys(text):

--- a/manubot/process/util.py
+++ b/manubot/process/util.py
@@ -26,7 +26,7 @@ from manubot.process.manuscript import (
     get_text,
     update_manuscript_citekeys,
 )
-from manubot.cite.util import (
+from manubot.cite.citekey import (
     citekey_to_csl_item,
     shorten_citekey,
     is_valid_citekey,

--- a/manubot/tests/test_imports.py
+++ b/manubot/tests/test_imports.py
@@ -1,10 +1,12 @@
 
 def test_imports():
     import manubot.cite
-    import manubot.cite.util
     import manubot.cite.arxiv
     import manubot.cite.doi
     import manubot.cite.pubmed
     import manubot.cite.url
     import manubot.process.manuscript
-    assert isinstance(manubot.cite.util.citeproc_retrievers, dict)
+
+def assert_instance_type():
+    from manubot.cite.citekey import citeproc_retrievers
+    assert isinstance(citeproc_retrievers, dict)


### PR DESCRIPTION
merges https://github.com/manubot/manubot/pull/139

Split the manubot.cite.util submodule into:
- manubot.cite.citekey
- manubot.cite.csl_item